### PR TITLE
Fix TikTok crawler headless setting and correct proxy path

### DIFF
--- a/functions/crawlers/tiktok.js
+++ b/functions/crawlers/tiktok.js
@@ -13,7 +13,7 @@ export async function runTikTok({ mode, keyword, urls, limits }) {
         launchContext: {
             useChrome: true,
             launchOptions: {
-                headless: true,
+                headless: false,
                 args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-blink-features=AutomationControlled', `--user-agent=${UA}`, '--lang=en-US,en']
             },
         },

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/social crawlers/i)).toBeInTheDocument();
 });

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -7,6 +7,7 @@ module.exports = function (app) {
         createProxyMiddleware({
             target: 'http://localhost:5001',
             changeOrigin: true,
+            pathRewrite: (path) => `/api${path}`,
         })
     );
 };


### PR DESCRIPTION
## Summary
- run TikTok crawler in headful mode
- move CRA proxy config into src and preserve `/api` prefix when forwarding to backend
- update test to match UI heading

## Testing
- `curl localhost:3000/api/health`
- `CI=true npm test`
- `npm test` (functions) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a62e95ecc08327a0b96e36f87e277f